### PR TITLE
fix: topic lists empty string

### DIFF
--- a/config/navsat_converter.yaml
+++ b/config/navsat_converter.yaml
@@ -19,6 +19,7 @@
         lat: 41.854693
         lon: 12.624754
         alt: 72.0
+      topic_stream: false
     target:
       frame: map
     tf:

--- a/include/navsat_converter/navsat_converter.hpp
+++ b/include/navsat_converter/navsat_converter.hpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,8 +115,16 @@ private:
   double earth_gps_lon_ = 0.0;
   double earth_gps_alt_ = 0.0;
   std::string target_frame_ = "";
+  bool earth_topic_stream_ = false;
   bool tf_ignore_stamp_ = false;
   int64_t tf_timeout_ms_ = 0;
+
+  /* Node Parameters Validators. */
+  bool validate_conv_gps_fix_topics(const rclcpp::Parameter & p);
+  bool validate_conv_xyz_odometry_topics(const rclcpp::Parameter & p);
+  bool validate_conv_xyz_point_topics(const rclcpp::Parameter & p);
+  bool validate_conv_xyz_pose_topics(const rclcpp::Parameter & p);
+  bool validate_conv_xyz_posecov_topics(const rclcpp::Parameter & p);
 
   /* Node Variables. */
   LocalCartesian coords;

--- a/launch/navsat_converter.launch.py
+++ b/launch/navsat_converter.launch.py
@@ -1,12 +1,12 @@
 """
-NMEA Driver app launch file.
+NavSatConverter Driver app launch file.
 
 Giorgio Manca <giorgio.manca.97@gmail.com>
 
-December 6, 2024
+July 8, 2025
 """
 
-# Copyright 2024 dotX Automation s.r.l.
+# Copyright 2025 dotX Automation s.r.l.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>navsat_converter</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <description>Node to convert GPS coordinates into cartesian coordinates and vice-versa.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation s.r.l.</maintainer>
   <license>Apache-2.0</license>

--- a/src/navsat_converter/navsat_converter.cpp
+++ b/src/navsat_converter/navsat_converter.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,14 +75,16 @@ void NavSatConverter::init_cgroups()
 
 void NavSatConverter::init_subscribers()
 {
-  coords_sub_ = dua_create_subscription<NavSatFix>(
-    coords_topic_,
-    std::bind(
-      &NavSatConverter::coords_clbk,
-      this,
-      std::placeholders::_1),
-    dua_qos::Reliable::get_datum_qos(),
-    coords_cgroup_);
+  if (earth_topic_stream_) {
+    coords_sub_ = dua_create_subscription<NavSatFix>(
+      coords_topic_,
+      std::bind(
+        &NavSatConverter::coords_clbk,
+        this,
+        std::placeholders::_1),
+      dua_qos::Reliable::get_datum_qos(),
+      coords_cgroup_);
+  }
 
   size_t idx;
 
@@ -259,22 +261,6 @@ void NavSatConverter::init_service_clients()
 
 void NavSatConverter::init_internals()
 {
-  while (conv_gps_fix_topics_.size() > 0 && conv_gps_fix_topics_.back().size() == 0) {
-    conv_gps_fix_topics_.pop_back();
-  }
-  while (conv_xyz_odometry_topics_.size() > 0 && conv_xyz_odometry_topics_.back().size() == 0) {
-    conv_xyz_odometry_topics_.pop_back();
-  }
-  while (conv_xyz_point_topics_.size() > 0 && conv_xyz_point_topics_.back().size() == 0) {
-    conv_xyz_point_topics_.pop_back();
-  }
-  while (conv_xyz_pose_topics_.size() > 0 && conv_xyz_pose_topics_.back().size() == 0) {
-    conv_xyz_pose_topics_.pop_back();
-  }
-  while (conv_xyz_posecov_topics_.size() > 0 && conv_xyz_posecov_topics_.back().size() == 0) {
-    conv_xyz_posecov_topics_.pop_back();
-  }
-
   coords = LocalCartesian(earth_gps_lat_, earth_gps_lon_, earth_gps_alt_);
 }
 

--- a/src/navsat_converter/navsat_converter_constants.cpp
+++ b/src/navsat_converter/navsat_converter_constants.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/navsat_converter/navsat_converter_publishers.cpp
+++ b/src/navsat_converter/navsat_converter_publishers.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/navsat_converter/navsat_converter_services.cpp
+++ b/src/navsat_converter/navsat_converter_services.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/navsat_converter/navsat_converter_subscriptions.cpp
+++ b/src/navsat_converter/navsat_converter_subscriptions.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/navsat_converter/navsat_converter_utils.cpp
+++ b/src/navsat_converter/navsat_converter_utils.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
  *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/navsat_converter/navsat_converter_validators.cpp
+++ b/src/navsat_converter/navsat_converter_validators.cpp
@@ -1,0 +1,106 @@
+/**
+ * NavSat Converter node validators.
+ *
+ * Giorgio Manca <giorgio.manca.97@gmail.com>
+ *
+ * July 8, 2025
+ */
+
+/**
+ * Copyright 2025 dotX Automation s.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <navsat_converter/navsat_converter.hpp>
+
+namespace navsat_converter
+{
+
+
+bool NavSatConverter::validate_conv_gps_fix_topics(const rclcpp::Parameter & p)
+{
+  std::vector<std::string> list = p.as_string_array();
+
+  conv_gps_fix_topics_.clear();
+  for (const std::string & topic : list) {
+    if (topic.length() > 0) {
+      conv_gps_fix_topics_.push_back(topic);
+    }
+  }
+
+  return true;
+}
+
+
+bool NavSatConverter::validate_conv_xyz_odometry_topics(const rclcpp::Parameter & p)
+{
+  std::vector<std::string> list = p.as_string_array();
+  
+  conv_xyz_odometry_topics_.clear();
+  for (const std::string & topic : list) {
+    if (topic.length() > 0) {
+      conv_xyz_odometry_topics_.push_back(topic);
+    }
+  }
+
+  return true;
+}
+
+
+bool NavSatConverter::validate_conv_xyz_point_topics(const rclcpp::Parameter & p)
+{
+  std::vector<std::string> list = p.as_string_array();
+
+  conv_xyz_point_topics_.clear();
+  for (const std::string & topic : list) {
+    if (topic.length() > 0) {
+      conv_xyz_point_topics_.push_back(topic);
+    }
+  }
+
+  return true;
+}
+
+
+bool NavSatConverter::validate_conv_xyz_pose_topics(const rclcpp::Parameter & p)
+{
+  std::vector<std::string> list = p.as_string_array();
+
+  conv_xyz_pose_topics_.clear();
+  for (const std::string & topic : list) {
+    if (topic.length() > 0) {
+      conv_xyz_pose_topics_.push_back(topic);
+    }
+  }
+
+  return true;
+}
+
+
+bool NavSatConverter::validate_conv_xyz_posecov_topics(const rclcpp::Parameter & p)
+{
+  std::vector<std::string> list = p.as_string_array();
+
+  conv_xyz_posecov_topics_.clear();
+  for (const std::string & topic : list) {
+    if (topic.length() > 0) {
+      conv_xyz_posecov_topics_.push_back(topic);
+    }
+  }
+
+  return true;
+}
+
+
+} // namespace navsat_converter

--- a/src/navsat_converter/params.yaml
+++ b/src/navsat_converter/params.yaml
@@ -6,47 +6,47 @@ params:
   conv.gps.fix_topics:
     type: string_array
     default_value:
-      - /fix
+      - ""
     description: "NavSatFix topics list."
     constraints: "Must be a list of valid topics name. Put a empty string to disable the conversion."
     read_only: true
-    var_name: conv_gps_fix_topics_
+    validator: validate_conv_gps_fix_topics
 
   conv.xyz.odometry_topics:
     type: string_array
     default_value: 
-      - /odometry
+      - ""
     description: "Odometry topics list."
     constraints: "Must be a list of valid topics name. Put a empty string to disable the conversion."
     read_only: true
-    var_name: conv_xyz_odometry_topics_
+    validator: validate_conv_xyz_odometry_topics
 
   conv.xyz.point_topics:
     type: string_array
     default_value:
-      - /point
+      - ""
     description: "PointStamped topics list."
     constraints: "Must be a list of valid topics name. Put a empty string to disable the conversion."
     read_only: true
-    var_name: conv_xyz_point_topics_
+    validator: validate_conv_xyz_point_topics
 
   conv.xyz.pose_topics:
     type: string_array
     default_value:
-      - /pose
+      - ""
     description: "PoseStamped topics list."
     constraints: "Must be a list of valid topics name. Put a empty string to disable the conversion."
     read_only: true
-    var_name: conv_xyz_pose_topics_
+    validator: validate_conv_xyz_pose_topics
 
   conv.xyz.posecov_topics:
     type: string_array
     default_value:
-      - /pose_cov
+      - ""
     description: "PoseWithCovarianceStamped topics list."
     constraints: "Must be a list of valid topics name. Put a empty string to disable the conversion."
     read_only: true
-    var_name: conv_xyz_posecov_topics_
+    validator: validate_conv_xyz_posecov_topics
 
   earth.frame:
     type: string
@@ -88,6 +88,14 @@ params:
     constraints: "Must be a valid real value."
     read_only: true
     var_name: earth_gps_alt_
+
+  earth.topic_stream:
+    type: bool
+    default_value: false
+    description: "Enable a NavSatFix to stream Earth frame coordinate updates."
+    constraints: "Should be off."
+    read_only: false
+    var_name: earth_topic_stream_
 
   target.frame:
     type: string

--- a/src/navsat_converter_app.cpp
+++ b/src/navsat_converter_app.cpp
@@ -3,11 +3,11 @@
  *
  * Giorgio Manca <giorgio.manca.97@gmail.com>
 *
- * December 6, 2024
+ * July 8, 2025
  */
 
 /**
- * Copyright 2024 dotX Automation s.r.l.
+ * Copyright 2025 dotX Automation s.r.l.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #4.

Add also a boolean parameter to disable a subscriber used to update Earth frame coordinates through the topic.

gnss_driver package version bumped to 1.0.4.