### PR TITLE
fix: service fail missing logs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>navsat_converter</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Node to convert GPS coordinates into cartesian coordinates and vice-versa.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation s.r.l.</maintainer>
   <license>Apache-2.0</license>

--- a/src/navsat_converter/navsat_converter_services.cpp
+++ b/src/navsat_converter/navsat_converter_services.cpp
@@ -38,7 +38,8 @@ void NavSatConverter::convert_gps_clbk(
   if(req->header.frame_id != earth_frame_) {
     res->success = false;
     RCLCPP_ERROR(this->get_logger(),
-      "GPS conversion failed: GPS coordinates source frame_id is not equal to Earth frame name");
+      "GPS conversion failed: GPS coordinates source frame_id (%s) != Earth frame (%s)",
+      req->header.frame_id.c_str(), earth_frame_.c_str());
     return;
   }
 
@@ -78,7 +79,8 @@ void NavSatConverter::convert_gps_clbk(
   } else {
     res->success = false;
     RCLCPP_ERROR(this->get_logger(),
-      "GPS conversion failed: XYZ coordinates target frame_id is not valid");
+      "GPS conversion failed: XYZ coordinates target frame_id (%s) is not valid",
+      req->target_frame_id.c_str());
   }
 }
 
@@ -93,7 +95,8 @@ void NavSatConverter::convert_xyz_clbk(
   if(req->target_frame_id != earth_frame_) {
     res->success = false;
     RCLCPP_ERROR(this->get_logger(),
-      "XYZ conversion failed: GPS coordinates target frame_id is not equal to Earth frame name");
+      "XYZ conversion failed: GPS coordinates target frame_id (%s) != Earth frame (%s)",
+      req->target_frame_id.c_str(), earth_frame_.c_str());
     return;
   }
 
@@ -133,7 +136,8 @@ void NavSatConverter::convert_xyz_clbk(
   } else {
     res->success = false;
     RCLCPP_ERROR(this->get_logger(),
-      "XYZ conversion failed: XYZ coordinates source frame_id is not valid");
+      "XYZ conversion failed: XYZ coordinates source frame_id (%s) is not valid",
+      req->header.frame_id.c_str());
   }
 }
 
@@ -150,7 +154,8 @@ void NavSatConverter::update_earth_clbk(
   } else {
     res->success = false;
     RCLCPP_ERROR(this->get_logger(),
-      "Earth coordinates update failed: frame_id is not the same");
+      "Earth coordinates update failed: frame_id is not the same (%s, %s)",
+      req->header.frame_id.c_str(), earth_frame_.c_str());
   }
 }
 

--- a/src/navsat_converter/navsat_converter_services.cpp
+++ b/src/navsat_converter/navsat_converter_services.cpp
@@ -37,6 +37,8 @@ void NavSatConverter::convert_gps_clbk(
 
   if(req->header.frame_id != earth_frame_) {
     res->success = false;
+    RCLCPP_ERROR(this->get_logger(),
+      "GPS conversion failed: GPS coordinates source frame_id is not equal to Earth frame name");
     return;
   }
 
@@ -75,6 +77,8 @@ void NavSatConverter::convert_gps_clbk(
     res->covariance[8] = xyz_cov(2, 2);
   } else {
     res->success = false;
+    RCLCPP_ERROR(this->get_logger(),
+      "GPS conversion failed: XYZ coordinates target frame_id is not valid");
   }
 }
 
@@ -88,6 +92,8 @@ void NavSatConverter::convert_xyz_clbk(
 
   if(req->target_frame_id != earth_frame_) {
     res->success = false;
+    RCLCPP_ERROR(this->get_logger(),
+      "XYZ conversion failed: GPS coordinates target frame_id is not equal to Earth frame name");
     return;
   }
 
@@ -126,6 +132,8 @@ void NavSatConverter::convert_xyz_clbk(
     res->covariance[8] = gps_cov(2, 2);
   } else {
     res->success = false;
+    RCLCPP_ERROR(this->get_logger(),
+      "XYZ conversion failed: XYZ coordinates source frame_id is not valid");
   }
 }
 
@@ -141,6 +149,8 @@ void NavSatConverter::update_earth_clbk(
     res->success = true;
   } else {
     res->success = false;
+    RCLCPP_ERROR(this->get_logger(),
+      "Earth coordinates update failed: frame_id is not the same");
   }
 }
 
@@ -155,8 +165,9 @@ bool NavSatConverter::get_isometry(const Header & hdr, Isometry3d & isometry)
 
   auto resp = get_transform_cli_->call_sync(req);
   if (resp->result.result == CommandResultStamped::ERROR) {
-    RCLCPP_ERROR(this->get_logger(), "Error requesting transform from %s to %s",
-        earth_frame_.c_str(), hdr.frame_id.c_str());
+    RCLCPP_ERROR(this->get_logger(),
+      "Error requesting transform from %s to %s",
+      earth_frame_.c_str(), hdr.frame_id.c_str());
     return false;
   }
 

--- a/src/navsat_converter/navsat_converter_subscriptions.cpp
+++ b/src/navsat_converter/navsat_converter_subscriptions.cpp
@@ -33,6 +33,9 @@ void NavSatConverter::coords_clbk(const NavSatFix::SharedPtr msg)
   if (msg->header.frame_id == earth_frame_) {
     std::lock_guard guard(coords_mutex);
     coords = LocalCartesian(msg->latitude, msg->longitude, msg->altitude);
+  } else {
+    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 1000,
+      "NavSatFix message frame_id is not equal to the Earth frame name");
   }
 }
 

--- a/src/navsat_converter/navsat_converter_subscriptions.cpp
+++ b/src/navsat_converter/navsat_converter_subscriptions.cpp
@@ -35,7 +35,8 @@ void NavSatConverter::coords_clbk(const NavSatFix::SharedPtr msg)
     coords = LocalCartesian(msg->latitude, msg->longitude, msg->altitude);
   } else {
     RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 1000,
-      "NavSatFix message frame_id is not equal to the Earth frame name");
+      "NavSatFix message frame_id (%s) != Earth frame (%s)",
+      msg->header.frame_id.c_str(), earth_frame_.c_str());
   }
 }
 


### PR DESCRIPTION
Add log error messages when a call to the services fails.
Bump version to 1.0.6